### PR TITLE
Optimization things...

### DIFF
--- a/src/main/resources/assets/nvidium/shaders/terrain/frag.frag
+++ b/src/main/resources/assets/nvidium/shaders/terrain/frag.frag
@@ -14,10 +14,15 @@
 
 layout(location = 0) out vec4 colour;
 layout(location = 1) in Interpolants {
-    f16vec4 uv_bias_cutoff;
+    f16vec2 uv;
     f16vec3 tint;
     f16vec3 addin;
 };
+
+layout(location=5) perprimitiveNV in PerPrimData {
+    int8_t lodBias;
+    uint8_t alphaCutoff;
+} prim_in;
 
 
 layout(binding = 0) uniform sampler2D tex_diffuse;
@@ -28,8 +33,8 @@ void main() {
     //uint uid = gl_PrimitiveID*132471+123571;
     //colour = vec4(float((uid>>0)&7)/7, float((uid>>3)&7)/7, float((uid>>6)&7)/7, 1.0);
     //colour = vec4(1.0,1.0,0,1);
-    colour = texture(tex_diffuse, uv_bias_cutoff.xy, uv_bias_cutoff.z);
-    if (colour.a < uv_bias_cutoff.w) discard;
+    colour = texture(tex_diffuse, uv, float(prim_in.lodBias) * (1.0 / 16.0));
+    if (colour.a < float(prim_in.alphaCutoff) * (1.0 / 255.0)) discard;
     colour.xyz *= tint;
     colour.xyz += addin;
     //colour = vec4(1.0,(uv_bias.z/-8.1f)+0.001f,0,1);

--- a/src/main/resources/assets/nvidium/shaders/terrain/mesh.glsl
+++ b/src/main/resources/assets/nvidium/shaders/terrain/mesh.glsl
@@ -17,14 +17,19 @@
 
 
 //It seems like for terrain at least, the sweat spot is ~16 quads per mesh invocation (even if the local size is not 32 )
-layout(local_size_x = 16) in;
+layout(local_size_x = 32) in;
 layout(triangles, max_vertices=64, max_primitives=32) out;
 
 layout(location=1) out Interpolants {
-    f16vec4 uv_bias_cutoff;
+    f16vec2 uv;
     f16vec3 tint;
     f16vec3 addin;
 } OUT[];
+
+layout(location=5) perprimitiveNV out PerPrimData {
+    int8_t lodBias;
+    uint8_t alphaCutoff;
+} per_prim_out[];
 
 taskNV in Task {
     vec3 origin;
@@ -45,21 +50,17 @@ vec4 sampleLight(uvec2 uv) {
 }
 
 
-void emitQuadIndicies() {
-    uint primBase = gl_LocalInvocationID.x * 6;
-    uint vertexBase = gl_LocalInvocationID.x<<2;
-    gl_PrimitiveIndicesNV[primBase+0] = vertexBase+0;
-    gl_PrimitiveIndicesNV[primBase+1] = vertexBase+1;
-    gl_PrimitiveIndicesNV[primBase+2] = vertexBase+2;
-    gl_PrimitiveIndicesNV[primBase+3] = vertexBase+2;
-    gl_PrimitiveIndicesNV[primBase+4] = vertexBase+3;
-    gl_PrimitiveIndicesNV[primBase+5] = vertexBase+0;
+void emitQuadIndicies(uint outVertexBase, uint sideOffset) {
+    uint primBase = gl_LocalInvocationID.x * 3;
+    gl_PrimitiveIndicesNV[primBase + 0] = outVertexBase + ((0 + sideOffset) & 3);
+    gl_PrimitiveIndicesNV[primBase + 1] = outVertexBase + ((1 + sideOffset) & 3);
+    gl_PrimitiveIndicesNV[primBase + 2] = outVertexBase + ((2 + sideOffset) & 3);
 }
 
-void emitVertex(uint vertexBaseId, uint innerId) {
-    Vertex V = terrainData[vertexBaseId + innerId];
-    uint outId = (gl_LocalInvocationID.x<<2)+innerId;
+void emitVertex(uint quadVertexBase, uint outVertexBase, uint innerId) {
+    Vertex V = terrainData[quadVertexBase + innerId];
 
+    uint outId = outVertexBase + innerId;
     vec3 pos = decodeVertexPosition(V)+origin;
     gl_MeshVerticesNV[outId].gl_Position = MVP*vec4(pos,1.0);
 
@@ -67,7 +68,7 @@ void emitVertex(uint vertexBaseId, uint innerId) {
     float mippingBias = decodeVertexMippingBias(V);
     float alphaCutoff = decodeVertexAlphaCutoff(V);
 
-    OUT[outId].uv_bias_cutoff = f16vec4(vec4(decodeVertexUV(V), mippingBias, alphaCutoff));
+    OUT[outId].uv = f16vec2(decodeVertexUV(V));
 
     vec4 tint = decodeVertexColour(V);
     tint *= sampleLight(decodeLightUV(V));
@@ -80,11 +81,19 @@ void emitVertex(uint vertexBaseId, uint innerId) {
     OUT[outId].addin = f16vec3(addiO);
 }
 
+void emitPerPrimativeData(uint vertexBaseId) {
+    Vertex V = terrainData[vertexBaseId];
+    int8_t lodBias = int8_t(clamp(decodeVertexMippingBias(V) * 16, -128, 127));
+    uint8_t alphaCutoff = uint8_t(decodeVertexAlphaCutoff(V) * 255);
+    per_prim_out[gl_LocalInvocationID.x].lodBias = lodBias;
+    per_prim_out[gl_LocalInvocationID.x].alphaCutoff = alphaCutoff;
+}
+
 
 //Do a binary search via global invocation index to determine the base offset
 // Note, all threads in the work group are probably going to take the same path
 uint getOffset() {
-    uint gii = gl_GlobalInvocationID.x;
+    uint gii = gl_GlobalInvocationID.x >> 1;
 
     //TODO: replace this with binary search
     if (gii < binIa.x) {
@@ -115,11 +124,13 @@ void main() {
     if (id == uint(-1)) {
         return;
     }
-    emitQuadIndicies();
-    emitVertex(id<<2, 0);
-    emitVertex(id<<2, 1);
-    emitVertex(id<<2, 2);
-    emitVertex(id<<2, 3);
+    uint quadVertexBase = id << 2;
+    uint outVertexBase = (gl_LocalInvocationID.x & uint(-2)) << 1;
+    uint sideOffset = (gl_LocalInvocationID.x & 1) * 2;
+    emitQuadIndicies(outVertexBase, sideOffset);
+    emitVertex(quadVertexBase, outVertexBase, sideOffset);
+    emitVertex(quadVertexBase, outVertexBase, sideOffset + 1);
+    emitPerPrimativeData(quadVertexBase);
 
     if (gl_LocalInvocationID.x == 0) {
         //Remaining quads in workgroup


### PR DESCRIPTION
Two changes:
- Moved alpha cutoff and lod bias to per-prim attributes, saved 4 bytes of interpolation, saved 4*64 - 2*32 = 192 bytes of shared memory usage
- Doubled workgroup size of mesh shaders to use the full 32, but kept the output size the same (still 16 quads)
- Now two threads process one quad, hopefully this soaks up more of the GPU memory backend (and don't need to waste registers)