### PR TITLE
Fixed the sky gradient being broken

### DIFF
--- a/src/main/java/me/cortex/nvidium/mixin/minecraft/MixinWorldRenderer.java
+++ b/src/main/java/me/cortex/nvidium/mixin/minecraft/MixinWorldRenderer.java
@@ -3,8 +3,10 @@ package me.cortex.nvidium.mixin.minecraft;
 import me.cortex.nvidium.Nvidium;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.util.math.MathHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(WorldRenderer.class)
@@ -25,5 +27,10 @@ public class MixinWorldRenderer {
             return dist == 32 * 16 ? viewDistance : (dist == 256 * 16 ? 9999999 : dist);
         }
         return viewDistance;
+    }
+
+    @ModifyArg(method = "method_37365", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/BackgroundRenderer;applyFog(Lnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/BackgroundRenderer$FogType;FZF)V"), index = 2)
+    private static float clampViewDistance(float viewDistance) {
+        return MathHelper.clamp(viewDistance, 2 * 16, 16 * 16);
     }
 }

--- a/src/main/java/me/cortex/nvidium/mixin/minecraft/MixinWorldRenderer.java
+++ b/src/main/java/me/cortex/nvidium/mixin/minecraft/MixinWorldRenderer.java
@@ -31,6 +31,6 @@ public class MixinWorldRenderer {
 
     @ModifyArg(method = "method_37365", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/BackgroundRenderer;applyFog(Lnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/BackgroundRenderer$FogType;FZF)V"), index = 2)
     private static float clampViewDistance(float viewDistance) {
-        return MathHelper.clamp(viewDistance, 2 * 16, 16 * 16);
+        return MathHelper.clamp(viewDistance, 2 * 16, 32 * 16);
     }
 }


### PR DESCRIPTION
Fix for the sky gradient being broken.
The view distance for the sky gradient is clamped between 2 and 32.

This is a fix for #62 and #151.

Before:
![Before](https://github.com/MCRcortex/nvidium/assets/20379977/4a61798c-4a95-47ca-9b91-03720d9c9492)

After:
![After](https://github.com/MCRcortex/nvidium/assets/20379977/648030ab-3dd5-4860-b946-39f588e24d4c)
