### PR TITLE
Make DeviceOnlyMappedBuffer non resident before deleting the buffer

### DIFF
--- a/src/main/java/me/cortex/nvidium/gl/buffers/DeviceOnlyMappedBuffer.java
+++ b/src/main/java/me/cortex/nvidium/gl/buffers/DeviceOnlyMappedBuffer.java
@@ -28,6 +28,7 @@ public class DeviceOnlyMappedBuffer extends GlObject implements IDeviceMappedBuf
     @Override
     public void delete() {
         super.free0();
+        glMakeNamedBufferNonResidentNV(id);
         glDeleteBuffers(id);
     }
 


### PR DESCRIPTION
As is done in PersistentSparseAddressableBuffer, making the buffer non resident allows the GPU memory allocated be freed when returning to the main menu or switching dimensions. Really noticeable on Linux.