### PR TITLE
Fix linux-specific memory leak

### DIFF
--- a/src/main/java/me/cortex/nvidium/gl/buffers/DeviceOnlyMappedBuffer.java
+++ b/src/main/java/me/cortex/nvidium/gl/buffers/DeviceOnlyMappedBuffer.java
@@ -28,6 +28,7 @@ public class DeviceOnlyMappedBuffer extends GlObject implements IDeviceMappedBuf
     @Override
     public void delete() {
         super.free0();
+        glMakeNamedBufferNonResidentNV(id);
         glDeleteBuffers(id);
     }
 

--- a/src/main/java/me/cortex/nvidium/gl/buffers/PersistentClientMappedBuffer.java
+++ b/src/main/java/me/cortex/nvidium/gl/buffers/PersistentClientMappedBuffer.java
@@ -7,6 +7,7 @@ import static org.lwjgl.opengl.ARBDirectStateAccess.*;
 import static org.lwjgl.opengl.GL30C.*;
 import static org.lwjgl.opengl.GL44.GL_CLIENT_STORAGE_BIT;
 import static org.lwjgl.opengl.GL44.GL_MAP_PERSISTENT_BIT;
+import static org.lwjgl.opengl.NVShaderBufferLoad.*;
 
 public class PersistentClientMappedBuffer extends GlObject implements IClientMappedBuffer {
     public final long addr;
@@ -28,6 +29,7 @@ public class PersistentClientMappedBuffer extends GlObject implements IClientMap
     public void delete() {
         super.free0();
         glUnmapNamedBuffer(id);
+        glMakeNamedBufferNonResidentNV(id);
         glDeleteBuffers(id);
     }
 


### PR DESCRIPTION
Buffers were not being marked as nonresident in memory despite deleting them, causing a memory leak and eventually crashing the game on specific linux nvidia drivers.

