### PR TITLE
replace deprecated gradle features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,27 @@
 plugins {
     id 'fabric-loom' version '1.10-SNAPSHOT'
     id 'maven-publish'
+    id 'java'
+    id 'base'
 }
 
-def gitCommitHash = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
-}
+def gitCommitHash = providers.exec {
+    commandLine 'git', 'rev-parse', '--short', 'HEAD'
+}.standardOutput.asText.map { it.trim() }
+
 def buildtime = System.currentTimeSeconds()
 
 version = project.mod_version
 group = project.maven_group
 
-sourceCompatibility = JavaVersion.VERSION_21
-targetCompatibility = JavaVersion.VERSION_21
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+base {
+    archivesName = "nvidium"
+}
 
 apply plugin: "fabric-loom"
 
@@ -32,11 +36,12 @@ loom {
 
 
 processResources {
-    inputs.properties("version": project.version, "commit": gitCommitHash, "buildtime":buildtime)
+    def ProjectVersion = project.version
 
-    archivesBaseName = "nvidium"
+    inputs.properties("version": ProjectVersion, "commit": gitCommitHash.get(), "buildtime": buildtime)
+
     filesMatching("fabric.mod.json") {
-        expand "commit": gitCommitHash, "version": project.version, "buildtime": buildtime
+        expand "commit": gitCommitHash.get(), "version": ProjectVersion, "buildtime": buildtime
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,22 @@ plugins {
     id 'base'
 }
 
-def gitCommitHash = providers.exec {
-    commandLine 'git', 'rev-parse', '--short', 'HEAD'
-}.standardOutput.asText.map { it.trim() }
-
-def buildtime = System.currentTimeSeconds()
+def gitCommitHash = { ->
+    try {
+        ExecOutput result = providers.exec {
+            commandLine = ['git', 'rev-parse', '--short', 'HEAD']
+            ignoreExitValue = true
+        }
+        if (result.getResult().get().getExitValue() != 0) {
+            return "<UnknownCommit>"
+        } else {
+            return result.standardOutput.asText.get().strip()
+        }
+    } catch (Exception e) {
+        e.printStackTrace()
+        return "<UnknownCommit>"
+    }
+}
 
 version = project.mod_version
 group = project.maven_group
@@ -37,12 +48,15 @@ loom {
 
 processResources {
     def ProjectVersion = project.version
-
-    inputs.properties("version": ProjectVersion, "commit": gitCommitHash.get(), "buildtime": buildtime)
-
-    filesMatching("fabric.mod.json") {
-        expand "commit": gitCommitHash.get(), "version": ProjectVersion, "buildtime": buildtime
+    def buildTimeProvider = project.provider { 
+        System.currentTimeSeconds()
     }
+ 
+    inputs.properties("version": ProjectVersion, "commit": gitCommitHash(), "buildtime": buildTimeProvider)
+    
+    filesMatching("fabric.mod.json") {
+        expand "commit": gitCommitHash(), "version": ProjectVersion, "buildtime": buildTimeProvider.get()
+    }    
 }
 
 repositories {
@@ -88,4 +102,3 @@ dependencies {
     //modImplementation "maven.modrinth:immersiveportals:v2.7.3-mc1.19.4"
     modCompileOnly "maven.modrinth:iris:1.9.0+1.21.6-fabric"
 }
-


### PR DESCRIPTION
Modernizes build script to fix Gradle deprecation warnings and prepare for Gradle 9.0 and 10.0

- Replaced deprecated  `exec(Closure)` with `providers.exec(Action)` https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#deprecated_project_exec
- Use `java` extension instead of deprecated JavaPluginConvention https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#java_convention_deprecation
- Replaced deprecated  `archivesBaseName` with `archivesName` https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#base_convention_deprecation
- Invocation of `Task.project` at execution time has been deprecated fixed that by capturing values during configuration https://docs.gradle.org/8.12/userguide/upgrading_version_7.html#task_project