### PR TITLE
Update Sodium support to 0.8.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.14-SNAPSHOT'
+    id 'fabric-loom' version '1.16-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -93,12 +93,10 @@ dependencies {
 
     modImplementation(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
 
-    modImplementation "net.caffeinemc:sodium-fabric:0.8.7+mc1.21.11"
-    modImplementation "net.caffeinemc:sodium-fabric-api:0.8.7+mc1.21.11"
+    modImplementation "net.caffeinemc:sodium-fabric:0.8.11+mc1.21.11"
 
     //modImplementation "maven.modrinth:c2me-fabric:0.2.0+alpha.10.49+1.19.4"
     //modImplementation "maven.modrinth:chunks-fade-in:v1.0.3-1.19.4"
     //modImplementation "maven.modrinth:immersiveportals:v2.7.3-mc1.19.4"
     modCompileOnly "maven.modrinth:iris:1.10.4+1.21.11-fabric"
 }
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ parchmentmc_mappings=2025.12.20
 fabric_version=0.140.2+1.21.11
 
 # Mod Properties
-mod_version=0.4.3-beta7-1.21.11
+mod_version=0.4.3-beta8-1.21.11
 maven_group=me.cortex
 archives_base_name=nvidium
 # Dependencies

--- a/src/main/java/me/cortex/nvidium/mixin/sodium/MixinRenderSectionManager.java
+++ b/src/main/java/me/cortex/nvidium/mixin/sodium/MixinRenderSectionManager.java
@@ -126,7 +126,7 @@ public class MixinRenderSectionManager implements INvidiumWorldRendererGetter {
     }
 
     @Inject(method = "getDebugStrings", at = @At("HEAD"), cancellable = true)
-    private void redirectDebug(CallbackInfoReturnable<Collection<String>> cir) {
+    private void redirectDebug(boolean showAdvanced, CallbackInfoReturnable<Collection<String>> cir) {
         if (Nvidium.IS_ENABLED) {
             var debugStrings = new ArrayList<String>();
             renderer.addDebugInfo(debugStrings);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,6 +29,6 @@
   "depends": {
     "fabricloader": ">=0.17.2",
     "minecraft": ["1.21.11"],
-    "sodium": ["=0.8.7"]
+    "sodium": ["=0.8.11"]
   }
 }


### PR DESCRIPTION
## Summary
 - update Fabric Loom to 1.16 for Sodium 0.8.11 metadata compatibility
 - update Sodium runtime/build dependency to 0.8.11 for Minecraft 1.21.11
 - bump mod version to 0.4.3-beta8-1.21.11
 - adjust the RenderSectionManager debug string mixin signature for Sodium 0.8.11